### PR TITLE
Load auth_ldap.ini on plugin registration

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 
+# 1.0.1 - 2018-03-24
+
+- Fix: properly load auth_ldap.ini
+
 # 1.0.0 - 201_-__-__
 
 - initial release

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ exports.hook_capabilities = function (next, connection) {
 
 exports.register = function () {
     this.inherits('auth/auth_base');
+    this.load_auth_ldap_ini();
 }
 
 exports.load_auth_ldap_ini = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-auth-ldap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Haraka plugin that uses an LDAP bind to authenticate users",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Load auth_ldap.ini on plugin registration

This appears to be a 'bug', in the sense that this plugin has omitted loading the ini file, while other plugins seem to load the ini file in the `register` function.
This PR is simply copying the implementation used in other auth plugins.
See:
[auth_bridge](https://github.com/haraka/Haraka/blob/master/plugins/auth/auth_bridge.js#L5)
[auth_vpopmaild](https://github.com/haraka/Haraka/blob/master/plugins/auth/auth_vpopmaild.js#L8)
[flat_file](https://github.com/haraka/Haraka/blob/master/plugins/auth/flat_file.js#L6)

Checklist:
- [ ] docs updated - **N/A**
- [ ] tests updated -**N/A**
- [x] Changes.md updated
- [x] package.json.version bumped
- [ ] published to NPM (will be done by @core)
