### PR TITLE
Allow PLAIN authentication if tls is active

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# 1.0.2 - 2018-09-18
+
+- New: add PLAIN authentication
 
 # 1.0.1 - 2018-03-24
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Configuration
 Configuration is stored in `config/auth_ldap.ini` and uses the INI
 style formatting.
 
-Only the `LOGIN` authentication method is supported assuming that passwords in the LDAP database are not stored in cleartext (which would allow for CRAM-MD5). Note that this means passwords will be sent in the clear to the LDAP server unless an `ldaps://` conection is used.
+`PLAIN` and `LOGIN` authentication methods are supported assuming that passwords in the LDAP database are not stored in cleartext (which would allow for CRAM-MD5). Note that this means passwords will be sent in the clear to the LDAP server unless an `ldaps://` conection is used.
 
 Current configuration options in `[core]` are:
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const async = require('async');
 exports.hook_capabilities = function (next, connection) {
     // Don't offer AUTH capabilities by default unless session is encrypted
     if (connection.tls.enabled) {
-        const methods = [ 'LOGIN' ];
+        const methods = [ 'PLAIN', 'LOGIN' ];
         connection.capabilities.push('AUTH ' + methods.join(' '));
         connection.notes.allowed_auth_methods = methods;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-auth-ldap",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Haraka plugin that uses an LDAP bind to authenticate users",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changes proposed in this pull request:

Added the PLAIN authentication method, since it uses exactly the same functionality as LOGIN, for example SOGo can only use PLAIN authentication.

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
- [ ] published to NPM (will be done by @core)
